### PR TITLE
DDT to create new user and check user's name in profile section

### DIFF
--- a/cypress/e2e/homeworks/hw_ddt/hw_ddt_test.cy.js
+++ b/cypress/e2e/homeworks/hw_ddt/hw_ddt_test.cy.js
@@ -1,0 +1,50 @@
+import newUserData from "../../../fixtures/add_user_data.json";
+import { faker } from "@faker-js/faker";
+import { LoginPage } from "../../../page-objects/pmtool/login_page";
+import { AddUserModal } from "../../../page-objects/pmtool/create_new_user_modal";
+
+describe("Homework data driven test", () => {
+  beforeEach(() => {
+    new LoginPage()
+      .openPmtool()
+      .typeUsername(Cypress.env("pmtool_username"))
+      .typePassword(Cypress.env("pmtool_password"))
+      .clickLogin()
+      .clickUsers()
+      .clickAddUser();
+  });
+
+  newUserData.forEach((newUserData) => {
+    it(`Add new user ${newUserData.description}, login new user and check username`, () => {
+      const username =
+        newUserData.name_prefix + faker.number.int({ max: 99999 });
+      const firstName = faker.person.firstName();
+      const lastName = faker.person.lastName();
+      const userEmail = faker.internet.email({
+        firstName: firstName,
+        lastName: lastName,
+        provider: "ab.tredgate.com",
+      });
+
+      cy.log(username);
+      cy.log(firstName);
+      cy.log(lastName);
+      cy.log(userEmail);
+
+      new AddUserModal()
+        .selectAccessGroup(newUserData.access_group)
+        .typeUsername(username)
+        .typePassword(newUserData.password)
+        .typeFirstName(firstName)
+        .typeLastName(lastName)
+        .typeEmail(userEmail)
+        .clickSave()
+        .clickProfile()
+        .clickLogout()
+        .typeUsername(username)
+        .typePassword(newUserData.password)
+        .clickLogin()
+        .usernameText.containsText(`${firstName} ${lastName}`);
+    });
+  });
+});

--- a/cypress/fixtures/add_user_data.json
+++ b/cypress/fixtures/add_user_data.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name_prefix": "manager_",
+    "access_group": "Manager",
+    "password": "managerPassword1#",
+    "description": "manager"
+  },
+  {
+    "name_prefix": "client_",
+    "access_group": "Client",
+    "password": "clientPassword2#",
+    "description": "client"
+  },
+  {
+    "name_prefix": "developer_",
+    "access_group": "Developer",
+    "password": "developerPassword3#",
+    "description": "developer"
+  }
+]

--- a/cypress/page-objects/pmtool/common/header_section.js
+++ b/cypress/page-objects/pmtool/common/header_section.js
@@ -1,20 +1,22 @@
+import { customElement } from "../../../helpers/custom_element";
 import { LoginPage } from "../login_page";
 import { MenuSection } from "./menu_section";
 
 export class HeaderSection extends MenuSection {
   constructor(path) {
     super(path);
-    this.profileButton = "#user_dropdown > .dropdown-toggle";
-    this.logoutButton = "#logout > a";
+    this.profileButton = customElement("#user_dropdown > .dropdown-toggle");
+    this.logoutButton = customElement("#logout > a");
+    this.usernameText = customElement(".username");
   }
 
   clickProfile() {
-    cy.get(this.profileButton).click();
+    this.profileButton.get().click();
     return this;
   }
 
   clickLogout() {
-    cy.get(this.logoutButton).click();
+    this.logoutButton.get().click();
     return new LoginPage();
   }
 }

--- a/cypress/page-objects/pmtool/create_new_user_modal.js
+++ b/cypress/page-objects/pmtool/create_new_user_modal.js
@@ -1,0 +1,51 @@
+import { customElement } from "../../helpers/custom_element";
+import { UserPage } from "./users_page";
+
+export class AddUserModal {
+  constructor() {
+    this.accessGroupSelect = customElement(
+      "[data-testid='Access Group'] select"
+    );
+    this.usernameInput = customElement("[data-testid='Username'] input");
+    this.passwordInput = customElement("#password");
+    this.firstNameInput = customElement("[data-testid='First Name'] input");
+    this.lastNameInput = customElement("[data-testid='Last Name'] input");
+    this.emailInput = customElement("[data-testid='User Email'] input");
+    this.saveButton = customElement("button[type='submit']");
+  }
+
+  selectAccessGroup(accessGroup) {
+    this.accessGroupSelect.get().select(accessGroup);
+    return this;
+  }
+
+  typeUsername(username) {
+    this.usernameInput.get().type(username);
+    return this;
+  }
+
+  typePassword(password) {
+    this.passwordInput.get().type(password);
+    return this;
+  }
+
+  typeFirstName(firstName) {
+    this.firstNameInput.get().type(firstName);
+    return this;
+  }
+
+  typeLastName(lastName) {
+    this.lastNameInput.get().type(lastName);
+    return this;
+  }
+
+  typeEmail(email) {
+    this.emailInput.get().type(email);
+    return this;
+  }
+
+  clickSave() {
+    this.saveButton.get().click();
+    return new UserPage();
+  }
+}

--- a/cypress/page-objects/pmtool/users_page.js
+++ b/cypress/page-objects/pmtool/users_page.js
@@ -1,5 +1,6 @@
 import { customElement } from "../../helpers/custom_element";
 import { HeaderSection } from "./common/header_section";
+import { AddUserModal } from "./create_new_user_modal";
 
 export class UserPage extends HeaderSection {
   constructor() {
@@ -7,6 +8,11 @@ export class UserPage extends HeaderSection {
     this.pageTitle = customElement("h3.page-title");
     this.addUserButton = customElement('[test_id="Add User"]');
     // this.pageTitle.get().should("contain.text", "Users");
+  }
+
+  clickAddUser() {
+    this.addUserButton.get().click();
+    return new AddUserModal();
   }
 
   titleIsVisible() {


### PR DESCRIPTION
Create new users with different role (manager, client, developer). Create DDT json file with username prefix, password and role. Test contains login to Pmtool, create new user, logout from current user account. Then login as new user created before and check first and last name in profile section.